### PR TITLE
Fix issue with PDF not displaying in viewer, fixes #2.

### DIFF
--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -22,7 +22,7 @@
     }
 }}
 {{=<% %>=}}
-<core-format-text text='<iframe src="<% config.wwwroot %>/mod/pdfprotect/pdfjs-drm/html5/?id=<% cmid %>&user_status=<% session %>&user_id=<% user_id %>"
+<core-format-text text='<iframe src="<% config.wwwroot %>/mod/pdfprotect/pdfjs-drm/html5/index.php?id=<% cmid %>&user_status=<% session %>&user_id=<% user_id %>"
                   frameborder="0" allowfullscreen="allowfullscreen"
                   style="width:100%;height:100%;"
                   width="100%" height="100%" ></iframe>'>

--- a/templates/view_page.mustache
+++ b/templates/view_page.mustache
@@ -28,4 +28,4 @@
         allow=":encrypted-media; :picture-in-picture"
         frameborder="0" allowfullscreen
         style="width:100%;height: calc(100vw * 1.4);"
-        src="{{config.wwwroot}}/mod/pdfprotect/pdfjs-drm/html5/?id={{id}}"></iframe>
+        src="{{config.wwwroot}}/mod/pdfprotect/pdfjs-drm/html5/index.php?id={{id}}"></iframe>


### PR DESCRIPTION
Hi,

This pull request updates the iframe source paths in the two template files to include `index.php` in the URL, ensuring proper loading of the pdf content.

### Updates to iframe source paths:
* [`templates/mobile_view_page.mustache`](diffhunk://#diff-617bddd98ce3a3cf2f314f25c9f555708b5c53b5d583939c1261483a8218145dL25-R25): Updated the iframe `src` attribute to include `index.php` in the URL for the mobile view page.
* [`templates/view_page.mustache`](diffhunk://#diff-5aa09a461f337503423c8828b2f4e3b9efa61f1df5c1be0c3fa54bf959cf2e86L31-R31): Updated the iframe `src` attribute to include `index.php` in the URL for the standard view page.

regards
Mario