### PR TITLE
Fix issue #3: deprecated dynamic properties in get_coursemodule_info

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -204,9 +204,11 @@ function pdfprotect_get_coursemodule_info($coursemodule) {
         $info->content = format_module_intro("pdfprotect", $pdfprotect, $coursemodule->id, false);
     }
 
-    $info->completionpassgrade = false;
-    $info->downloadcontent = false;
-    $info->lang = false;
+    $info->customdata = [
+        'completionpassgrade' => false,
+        'downloadcontent' => false,
+        'lang' => false,
+    ];
 
     return $info;
 }


### PR DESCRIPTION
Hi,

This pull request updates pdfprotect_get_coursemodule_info to prevent PHP Deprecated warnings related to the creation of dynamic properties on the cached_cm_info object (introduced in PHP 8.2).

The custom flags 'completionpassgrade', 'downloadcontent', and 'lang' are now stored within the standard `$info->customdata` array instead of being assigned directly as dynamic properties to the object.

This change addresses the errors reported in issue #3.

File affected: mod/pdfprotect/lib.php